### PR TITLE
エラーログをもとにfile_contextsを記述

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,0 +1,1 @@
+/vendor/bin/hw/android.hardware.audio@4.0-service-mediatek u:object_r:audioserver_exec:s0 


### PR DESCRIPTION
下記エラーの解決
```

[ 160.508259] -(3)[1:init]init: Command 'start vendor.audio-hal-2-0' action=init.svc.audioserver=running (/system/etc/init/audioserver.rc:36) took 0ms and failed: service vendor.audio-hal-2-0 not found 

[ 160.508313] -(3)[1:init]init: Command 'start audio-hal-2-0' action=init.svc.audioserver=running (/system/etc/init/audioserver.rc:37) took 0ms and failed: service audio-hal-2-0 not found 

[ 160.592225] -(0)[1:init]init: Control message: Could not ctl.interface_start for 'android.hardware.audio@4.0::IDevicesFactory/default' from pid: 277 (/system/bin/hwservicemanager): File /vendor/bin/hw/android.hardware.audio@4.0-service-mediatek (labeled "u:object_r:vendor_file:s0") has incorrect label or no domain transition from u:r:init:s0 to another SELinux domain defined. Have you configured your service correctly? https://source.android.com/security/selinux/device-policy#label_new_services_and_address_denials
```